### PR TITLE
s/uuid/udid

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,7 +43,7 @@ IDevice.prototype._build_cmd = function (options) {
 
     cmd += this.cmd;
 
-    if (this.uuid) {
+    if (this.udid) {
 	cmd += " -U " + this.udid;
     }
 
@@ -170,6 +170,6 @@ IDevice.prototype.installAndWait = function (ipa, app, cb) {
 }
 
 
-module.exports = function (uuid, opts) {
-  return new IDevice(uuid, opts);
+module.exports = function (udid, opts) {
+  return new IDevice(udid, opts);
 };

--- a/main.js
+++ b/main.js
@@ -44,7 +44,7 @@ IDevice.prototype._build_cmd = function (options) {
     cmd += this.cmd;
 
     if (this.udid) {
-	cmd += " -U " + this.udid;
+	cmd += " -u " + this.udid;
     }
 
     if (typeof options == 'object' && options.indexOf) {


### PR DESCRIPTION
Fix for a bug that makes node-idevice install the app on the wrong device sometimes if more than one device are connected to the same machine.

Also replace the deprecated `-U` with `-u`.