### PR TITLE
Handle new style of output from list in ideviceinstaller

### DIFF
--- a/main.js
+++ b/main.js
@@ -72,10 +72,18 @@ IDevice.prototype.list = function (option, cb) {
 	    var apps = stdout.split('\n'),
 		res = [];
 	    for (var i = 0; i < apps.length; i++) {
+               // handle old-style output
 		var info = apps[i].split(' - ');
-		if (info.length == 2) {
+		if (info.length === 2) {
 		    res.push({name: info[1], fullname: info[0]});
 		}
+
+               // handle new-style output
+               info = apps[i].replace(/"/g, "").split(",");
+               if (info.length === 3) {
+                   var name = info[2].trim() + " " + info[1].trim();
+                   res.push({name: name, fullname: info[0]});
+               }
 	    }
 	    cb(null, res);
 	}


### PR DESCRIPTION
ideviceinstaller has a different format for the list of apps. If it is installed with brew normally (i.e., `brew install ideviceinstaller`) the list returned from `ideviceinstaller -l` is:

```shell
Total: 40 apps
com.sonos.SonosController - Sonos 28.1.86171
com.tinyspeck.chatlyio - Slack 43000
...
```

If it is installed with brew from head (i.e., `brew install --HEAD ideviceinstaller`), the list is:

```shell
CFBundleIdentifier, CFBundleVersion, CFBundleDisplayName
com.sonos.SonosController, "28.1.86171", "Sonos"
com.tinyspeck.chatlyio, "43000", "Slack"
...
```

This PR handles that case and creates a list with the same properties as the old style.