### PR TITLE
Stop using deprecated uninstall flag

### DIFF
--- a/main.js
+++ b/main.js
@@ -135,7 +135,7 @@ IDevice.prototype.listAll = function (cb) {
 };
 
 IDevice.prototype.remove = function (app, cb) {
-    exec(this._build_cmd(['-u', app]), function (err, stdout, stderr) {
+    exec(this._build_cmd(['-U', app]), function (err, stdout, stderr) {
 	if (err) {
 	    cb(err, stdout);
 	} else {


### PR DESCRIPTION
`ideviceinstaller` complains when using `-u` to uninstall.

See https://github.com/appium/appium/issues/6487